### PR TITLE
Port Fabric version to Minecraft 1.21.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Shulker Loader
+
+Shulker Loader redirects item pickups into a shulker box held in the player's offhand.
+
+## Minecraft 1.21.10 Fabric Port
+
+This port targets Minecraft 1.21.10 on Fabric.
+
+Supported versions:
+
+- Minecraft 1.21.10
+- Fabric Loader 0.17.3 or newer
+- Fabric API for Minecraft 1.21.10
+- Java 21
+
+## Installation
+
+Install the mod jar on both the client and the server. For singleplayer, install it in the client's `mods` folder.
+
+The 1.21.10 port is not documented as server-only because the current port should be present on both sides when joining a Fabric server.
+
+## Behavior
+
+When the player holds exactly one shulker box in the offhand, picked-up non-shulker items are inserted into that offhand shulker box before normal inventory pickup handling.
+
+Limits:
+
+- Shulker boxes are not inserted into other shulker boxes.
+- The offhand shulker box stack must have `count == 1`.
+- When the offhand shulker box is full, or the picked-up item cannot fit, the remaining items continue through the normal vanilla inventory pickup flow.
+
+## Upgrade Notes
+
+Minecraft 1.21.10 changed the `PlayerInventory` structure used by older builds. Direct access to the old offhand field is no longer compatible and can crash with `NoSuchFieldError` for `field_7544`.
+
+This port fixes the 1.21.10 pickup crash by using the public offhand stack API instead of accessing the removed inventory field.
+
+## Test Steps
+
+1. Install the jar on both the client and the server.
+2. Start Minecraft 1.21.10 with Fabric.
+3. Put an empty shulker box in the player's offhand.
+4. Drop and pick up a stack of normal stackable items.
+5. Confirm the items go into the offhand shulker box and the game does not crash.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.16.1'
 	id 'maven-publish'
 }
 
@@ -33,7 +33,7 @@ loom {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.1
-yarn_mappings=1.21.1+build.3
-loader_version=0.16.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
+loader_version=0.17.3
 
 # Mod Properties
-mod_version=1.0.11
+mod_version=1.0.12+mc1.21.10
 maven_group=com.fexl
 archives_base_name=shulkerloader
 
 # Dependencies
-fabric_version=0.102.1+1.21.1
+fabric_version=0.138.4+1.21.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/fexl/shulkerloader/mixin/ShulkerLoad.java
+++ b/src/main/java/com/fexl/shulkerloader/mixin/ShulkerLoad.java
@@ -1,46 +1,42 @@
 package com.fexl.shulkerloader.mixin;
 
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.item.component.ItemContainerContents;
+import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.block.ShulkerBoxBlock;
+import net.minecraft.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ContainerComponent;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.collection.DefaultedList;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.advancements.CriteriaTriggers;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.NonNullList;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.stats.Stats;
-
-import java.util.Objects;
-
 @Mixin(ItemEntity.class)
 public class ShulkerLoad {
 
-	@Inject(method = "Lnet/minecraft/world/entity/item/ItemEntity;playerTouch(Lnet/minecraft/world/entity/player/Player;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;add(Lnet/minecraft/world/item/ItemStack;)Z", ordinal = 0), cancellable = true)
-	private void itemPickupEvent(Player player, CallbackInfo event) {
+	@Inject(method = "onPlayerCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;insertStack(Lnet/minecraft/item/ItemStack;)Z", ordinal = 0), cancellable = true)
+	private void itemPickupEvent(PlayerEntity player, CallbackInfo event) {
 		ItemEntity itemEntity = (ItemEntity)(Object) this;
-		Inventory playerInv = player.getInventory();
-		ItemStack offhand_item = playerInv.offhand.get(0);
-		ItemStack pickup_item = itemEntity.getItem();
+		PlayerInventory playerInv = player.getInventory();
+		ItemStack offhand_item = player.getOffHandStack();
+		ItemStack pickup_item = itemEntity.getStack();
 
 		//Check the player is carrying a shulker box, the item picked up is NOT a shulker box, the shulker box has a stack size of one, and the shulker box contains an inventory.
-		if(!isShulkerBox(offhand_item) || isShulkerBox(pickup_item) || !offhand_item.getComponents().keySet().contains(DataComponents.CONTAINER) || offhand_item.getCount() > 1) {
+		if(!isShulkerBox(offhand_item) || isShulkerBox(pickup_item) || offhand_item.getCount() > 1 || !(player instanceof ServerPlayerEntity serverPlayer)) {
 			return;
 		}
 		
 		//Stores the shulker box contents for processing
-		NonNullList<ItemStack> shulkerInv = NonNullList.withSize((new ShulkerBoxBlockEntity(BlockPos.ZERO, Blocks.SHULKER_BOX.defaultBlockState())).getContainerSize(), ItemStack.EMPTY);
-		offhand_item.getComponents().get(DataComponents.CONTAINER).copyInto(shulkerInv);
+		DefaultedList<ItemStack> shulkerInv = DefaultedList.ofSize(ShulkerBoxBlockEntity.INVENTORY_SIZE, ItemStack.EMPTY);
+		offhand_item.getOrDefault(DataComponentTypes.CONTAINER, ContainerComponent.DEFAULT).copyTo(shulkerInv);
 
 		//Count after processing
 		int processed_count = checkSlots(pickup_item, shulkerInv);
@@ -53,36 +49,40 @@ public class ShulkerLoad {
 			return;
 		}
 
-		//Retrieve the amount of items the player picked up
-		ItemStack pickup_amount = pickup_item.copy();
-		pickup_amount.setCount(previous_count - processed_count);
-		
-		//Grant advancements associated with picking up the item
-		CriteriaTriggers.INVENTORY_CHANGED.trigger((ServerPlayer)player, playerInv, pickup_amount);
-				
-		//Update player statistics with the item
-		player.awardStat(Stats.ITEM_PICKED_UP.get(pickup_item.getItem()), pickup_amount.getCount());
-		
 		//Set the count of the pickup item
 		pickup_item.setCount(processed_count);
+
+		//Let the player's inventory handle any item quantity that did not fit into the shulker.
+		playerInv.insertStack(pickup_item);
+
+		//Retrieve the amount of items the player picked up
+		ItemStack pickup_amount = pickup_item.copy();
+		pickup_amount.setCount(previous_count - pickup_item.getCount());
 		
 		//Cancel the event so it isn't also processed by the inventory
 		event.cancel();
 		
 		//Shows the player pickup animation
-		player.take(itemEntity, pickup_amount.getCount());
+		serverPlayer.sendPickup(itemEntity, pickup_amount.getCount());
 		
 		if(pickup_item.getCount() == 0) { 
-			//Kill the ItemEntity
-			itemEntity.kill();
+			//Remove the ItemEntity
+			itemEntity.discard();
 		}
 
+		//Grant advancements associated with picking up the item
+		Criteria.INVENTORY_CHANGED.trigger(serverPlayer, playerInv, pickup_amount);
+
+		//Update player statistics with the item
+		player.increaseStat(Stats.PICKED_UP.getOrCreateStat(pickup_item.getItem()), pickup_amount.getCount());
+		serverPlayer.triggerItemPickedUpByEntityCriteria(itemEntity);
+
 		//Set the shulker box tag equal to the new one
-		offhand_item.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(shulkerInv));
+		offhand_item.set(DataComponentTypes.CONTAINER, ContainerComponent.fromStacks(shulkerInv));
 	}
 	
 	//Ported from Inventory.class
-	private int getFreeSlot(NonNullList<ItemStack> items) {
+	private int getFreeSlot(DefaultedList<ItemStack> items) {
 		for(int i = 0; i < items.size(); ++i) {
 			if (items.get(i).isEmpty()) {
 				return i;
@@ -94,11 +94,11 @@ public class ShulkerLoad {
 		
 	//Ported from Inventory.class
 	private boolean hasRemainingSpaceForItem(ItemStack item1, ItemStack item2) {
-	      return !item1.isEmpty() && ItemStack.isSameItemSameComponents(item1, item2) && item1.isStackable() && item1.getCount() < item1.getMaxStackSize() && item1.getCount() < 64;
+	      return !item1.isEmpty() && ItemStack.areItemsAndComponentsEqual(item1, item2) && item1.isStackable() && item1.getCount() < item1.getMaxCount() && item1.getCount() < 64;
 	}
 		   
 	//Ported from Inventory.class
-	private int getSlotWithRemainingSpace(ItemStack item, NonNullList<ItemStack> items) {
+	private int getSlotWithRemainingSpace(ItemStack item, DefaultedList<ItemStack> items) {
 		for(int i = 0; i < items.size(); ++i) {
 			if (this.hasRemainingSpaceForItem(items.get(i), item)) {
 				return i;
@@ -108,9 +108,9 @@ public class ShulkerLoad {
 	}
 	
 	//Distribute an ItemStack into the components of an ItemStack list and return the remainder
-	private int checkSlots(ItemStack item, NonNullList<ItemStack> items) {
+	private int checkSlots(ItemStack item, DefaultedList<ItemStack> items) {
 		//True if the stack has been fully transferred into items
-		Boolean item_transferred = false;
+		boolean item_transferred = false;
 		
 		//Copy item for processing
 		ItemStack pickup_item_copy = item.copy();
@@ -124,7 +124,7 @@ public class ShulkerLoad {
 			int combined_stack = shulker_item.getCount() + pickup_item_copy.getCount();
 			
 			//If pickup item fits in selected stack
-			if(combined_stack <= shulker_item.getMaxStackSize()) {
+			if(combined_stack <= shulker_item.getMaxCount()) {
 				shulker_item.setCount(combined_stack);
 				pickup_item_copy.setCount(0);
 				items.set(stack_avaliable, shulker_item);
@@ -132,12 +132,12 @@ public class ShulkerLoad {
 				break;
 			}
 			//How much stack capacity is left
-			int stack_left = shulker_item.getMaxStackSize() - shulker_item.getCount();
+			int stack_left = shulker_item.getMaxCount() - shulker_item.getCount();
 			
 			//If pickup item doesn't fit in selected stack
 			if(pickup_item_copy.getCount() > stack_left) {
 				pickup_item_copy.setCount(pickup_item_copy.getCount()-stack_left);
-				shulker_item.setCount(shulker_item.getMaxStackSize());
+				shulker_item.setCount(shulker_item.getMaxCount());
 				items.set(stack_avaliable, shulker_item);
 				stack_avaliable = this.getSlotWithRemainingSpace(pickup_item_copy, items);
 				continue;
@@ -155,17 +155,12 @@ public class ShulkerLoad {
 		return pickup_item_copy.getCount();
 	}
 	//Overloaded with ItemStack
-	private Boolean isShulkerBox(ItemStack item) {
+	private boolean isShulkerBox(ItemStack item) {
 		return this.isShulkerBox(item.getItem());
 	}
 
 	//Check if shulker
-	private Boolean isShulkerBox(Item item) {
-		//Get item registry name without namespace
-		String item_name = BuiltInRegistries.ITEM.getKey(item).getPath();
-
-		if (item_name.endsWith("shulker_box"))
-			return true;
-		return false;
+	private boolean isShulkerBox(Item item) {
+		return item instanceof BlockItem blockItem && blockItem.getBlock() instanceof ShulkerBoxBlock;
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "shulkerloader",
-  "version": "1.0.10",
+  "version": "${version}",
 
   "name": "Shulker Loader",
   "description": "Redirects item pickups into an offhand shulker box!",
@@ -28,8 +28,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.10",
-    "minecraft": ">=1.21",
+    "fabricloader": ">=0.17.3",
+    "minecraft": ">=1.21.10 <1.21.11",
     "java": ">=21"
   }
 }

--- a/src/main/resources/shulkerloader.mixins.json
+++ b/src/main/resources/shulkerloader.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.fexl.shulkerloader.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   	"ShulkerLoad"
   ],


### PR DESCRIPTION
﻿## Summary

- Port the Fabric build to Minecraft 1.21.10 with Yarn 1.21.10+build.3 and Fabric API 0.138.4+1.21.10.
- Fix the pickup crash caused by the 1.21.10 PlayerInventory offhand field change by using the public offhand stack API instead of the removed field.
- Keep Fabric Loader metadata compatible with 0.17.3+ instead of requiring 0.19.2+.
- Update documentation for the 1.21.10 port and note that the jar should be installed on both client and server.

## Compatibility notes

Minecraft 1.21.10 changed the PlayerInventory layout, so direct access to the old offhand field can fail at runtime with NoSuchFieldError / field_7544. This port keeps the original offhand shulker pickup behavior while avoiding direct field access.

The mod metadata now declares:

- fabricloader >=0.17.3
- minecraft >=1.21.10 <1.21.11
- environment *

For this 1.21.10 port, the README documents installing the jar on both the client and the server.

## Test steps

- Install the jar on both client and server.
- Put one empty shulker box in the player's offhand.
- Pick up a stack of normal non-shulker items.
- Confirm the items enter the offhand shulker box and pickup no longer crashes with NoSuchFieldError / field_7544.
- Confirm overflow or incompatible items continue through normal vanilla pickup handling.

## Validation

- Ran `./gradlew.bat clean build`
- Checked the remapped jar's `fabric.mod.json` for the expected Minecraft, Fabric Loader, and environment metadata.
